### PR TITLE
[Edric]-[Regex for searching with symbols: /(OR) and ~(synonyms)]

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -99,7 +99,7 @@ app.get('/keywords', (req, res) => {
             results = symbolSearcher.searchWithOr(query, matchOR, symbolSearcher.searchWithOr, results)
         }
 
-       symbolSearcher.searchWithSynonyms(query, results);
+       results = symbolSearcher.searchWithSynonyms(query, results);
 
         responseData.status = 1;
         responseData.message = "success";

--- a/server/server.js
+++ b/server/server.js
@@ -3,6 +3,7 @@ const express = require("express")
 const app = express()
 const natural = require('natural')
 const tokenizer = new natural.WordTokenizer()
+const sentenceTokenizer = new natural.SentenceTokenizer()
 const wordnet = new natural.WordNet();
 const firebase = require("firebase-admin")
 const fs = require('fs')
@@ -77,6 +78,42 @@ app.get('/query', (req, res) => {
         });
     } else {
         responseData.message = "search string not provided."
+        res.json(responseData);
+    }
+});
+
+app.get('/getSentences', (req, res) => {
+    const sentences = [];
+    const responseData = {
+        status: 0,
+        message: '',
+        sentenceCount: 0,
+        sentences: sentences
+    };
+
+    if(req.query.search !== undefined) {
+        fs.readdir(directoryPath, function (err, files) {
+            if (err) {
+                return console.log('Unable to scan directory: ' + err);
+            }
+
+            files.forEach(function (file) {
+                const allFileContents = fs.readFileSync('resources/documents/' + file, 'utf-8');
+                sentenceTokenizer.tokenize(allFileContents).forEach(function (sentence) {
+                    if (sentence.includes(req.query.search)) {
+                        sentences.push(sentence)
+                    }
+                })
+            });
+
+            responseData.status = 1;
+            responseData.message = "success";
+            responseData.sentenceCount = sentences.length
+
+            res.json(responseData);
+        });
+    } else {
+        responseData.message = "No phrase was provided."
         res.json(responseData);
     }
 });

--- a/server/server.js
+++ b/server/server.js
@@ -83,7 +83,7 @@ app.get('/query', (req, res) => {
     }
 });
 
-app.get('/keywords', (req, res) => {
+app.get('/keywords', async (req, res) => {
     const responseData = {
         status: 0,
         message: '',
@@ -98,8 +98,9 @@ app.get('/keywords', (req, res) => {
             // search here
             results = symbolSearcher.searchWithOr(query, matchOR, symbolSearcher.searchWithOr, results)
         }
-
-       results = symbolSearcher.searchWithSynonyms(query, results);
+        await symbolSearcher.searchWithSynonyms(query, results).then(value =>
+            results = value
+        );
 
         responseData.status = 1;
         responseData.message = "success";

--- a/server/server.js
+++ b/server/server.js
@@ -92,15 +92,19 @@ app.get('/keywords', (req, res) => {
 
     let query = req.query.search
     if (query !== undefined) {
+        let results = []
         let matchOR = query.match(/\w+\/\w+/g)
         if (matchOR != null) {
-            let results = []
-            responseData.match = symbolSearcher.searchWithOr(query, matchOR, symbolSearcher.searchWithOr, results);
-        } else {
-            responseData.match = "n/a";
+            // search here
+            results = symbolSearcher.searchWithOr(query, matchOR, symbolSearcher.searchWithOr, results)
         }
+
+       symbolSearcher.searchWithSynonyms(query, results);
+
         responseData.status = 1;
         responseData.message = "success";
+        responseData.match = results;
+        // Search all files with results array
 
         res.json(responseData);
     } else {

--- a/server/server.js
+++ b/server/server.js
@@ -9,6 +9,7 @@ const firebase = require("firebase-admin")
 const fs = require('fs')
 const path = require('path')
 require("firebase/firestore");
+const symbolSearcher = require("./utils/symbol-searcher");
 
 const directoryPath = path.join(__dirname, 'resources/documents');
 
@@ -76,6 +77,32 @@ app.get('/query', (req, res) => {
             
             res.json(responseData);
         });
+    } else {
+        responseData.message = "search string not provided."
+        res.json(responseData);
+    }
+});
+
+app.get('/keywords', (req, res) => {
+    const responseData = {
+        status: 0,
+        message: '',
+        match: []
+    };
+
+    let query = req.query.search
+    if (query !== undefined) {
+        let matchOR = query.match(/\w+\/\w+/g)
+        if (matchOR != null) {
+            let results = []
+            responseData.match = symbolSearcher.searchWithOr(query, matchOR, symbolSearcher.searchWithOr, results);
+        } else {
+            responseData.match = "n/a";
+        }
+        responseData.status = 1;
+        responseData.message = "success";
+
+        res.json(responseData);
     } else {
         responseData.message = "search string not provided."
         res.json(responseData);

--- a/server/utils/symbol-searcher.js
+++ b/server/utils/symbol-searcher.js
@@ -56,6 +56,9 @@ function searchWithSynonyms(query, results) {
             })
         })
     }
+    // this doesn't work due to wordnet.lookup being a callback
+    // TODO: wait for completion somehwow?
+    return results
 }
 
 module.exports = { searchWithOr, searchWithSynonyms };

--- a/server/utils/symbol-searcher.js
+++ b/server/utils/symbol-searcher.js
@@ -1,25 +1,61 @@
+const natural = require("natural");
+const wordnet = new natural.WordNet();
+
 function searchWithOr(query, array, callback, results) {
-    if (array.length > 1) {
-        array.forEach((string, index) => {
-            string.split("/").forEach(orWord => {
-                let searched = query.replace(array[index], orWord)
-                let isMatchingOR = searched.match(/\w+\/\w+/g)
-                if (isMatchingOR && array.length - 1 === index) {
-                    callback(searched, isMatchingOR, callback, results)
-                }
-            })
-        })
-    } else {
-        array.forEach(string => {
-                string.split("/").forEach(word => {
-                        let searchQuery = query.replace(/\w+\/\w+/g, word)
-                        results.push(searchQuery)
+    let matchOR = query.match(/\w+\/\w+/g)
+    if (matchOR != null) {
+        if (array.length > 1) {
+            array.forEach((string, index) => {
+                string.split("/").forEach(orWord => {
+                    let searched = query.replace(array[index], orWord)
+                    let isMatchingOR = searched.match(/\w+\/\w+/g)
+                    if (isMatchingOR && array.length - 1 === index) {
+                        callback(searched, isMatchingOR, callback, results)
                     }
-                )
-            }
-        )
+                })
+            })
+        } else {
+            array.forEach(string => {
+                    string.split("/").forEach(word => {
+                            let searchQuery = query.replace(/\w+\/\w+/g, word)
+                            results.push(searchQuery)
+                        }
+                    )
+                }
+            )
+        }
     }
     return results
 }
 
-module.exports = { searchWithOr };
+function searchWithSynonyms(query, results) {
+    let wordSynonyms = []
+    let matchSynonym;
+    if (results.length === 0) {
+        matchSynonym = query.match(/~\w+/g)
+    } else {
+        matchSynonym = results.map(match => match.match(/~\w+/g))
+    }
+    if (matchSynonym != null) {
+        matchSynonym.forEach(matchingString => {
+            let filteredString = matchingString[0].replace("~", "")
+            wordnet.lookup(filteredString, (_results) => {
+                _results.forEach((result) => {
+                    result.synonyms.forEach((_syn) => {
+                        if (
+                            _syn.toLowerCase() !== filteredString.toLowerCase() &&
+                            !wordSynonyms.includes(_syn)
+                        ) {
+                            wordSynonyms.push(_syn)
+                            results.forEach(data =>
+                                results.push(data.replace(matchingString[0], _syn))
+                            )
+                        }
+                    })
+                })
+            })
+        })
+    }
+}
+
+module.exports = { searchWithOr, searchWithSynonyms };

--- a/server/utils/symbol-searcher.js
+++ b/server/utils/symbol-searcher.js
@@ -1,0 +1,25 @@
+function searchWithOr(query, array, callback, results) {
+    if (array.length > 1) {
+        array.forEach((string, index) => {
+            string.split("/").forEach(orWord => {
+                let searched = query.replace(array[index], orWord)
+                let isMatchingOR = searched.match(/\w+\/\w+/g)
+                if (isMatchingOR && array.length - 1 === index) {
+                    callback(searched, isMatchingOR, callback, results)
+                }
+            })
+        })
+    } else {
+        array.forEach(string => {
+                string.split("/").forEach(word => {
+                        let searchQuery = query.replace(/\w+\/\w+/g, word)
+                        results.push(searchQuery)
+                    }
+                )
+            }
+        )
+    }
+    return results
+}
+
+module.exports = { searchWithOr };


### PR DESCRIPTION
Changed:
- Added keywords endpoint to test searching with symbols:
  - Added searching with / symbol to search with OR
  - Added searching with ~ symbol to search for synonyms
- Added get sentences with word endpoint for testing natural library (may be not needed)

Accidentally somehow committed with work account at the start 🤦 and then after that it stopped working
